### PR TITLE
limiting CI prod pipeline to release tags

### DIFF
--- a/.github/workflows/django-prod.yml
+++ b/.github/workflows/django-prod.yml
@@ -3,7 +3,7 @@ name: Django CI Prod
 on:
   create:
       tags:
-        - '*'
+        - 'release-*'
 
 jobs:
   build:


### PR DESCRIPTION
As it is trigger the action for tags and branches. Trying to limit it to only release-* named tags.